### PR TITLE
Expose store

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,6 @@ import Notifications from './components/Notifications.svelte';
 import { getNotificationsContext } from './context';
 import notificationsStore from './store';
 
-export { getNotificationsContext, notificationsStore } from './context';
+export { getNotificationsContext, notificationsStore };
 
 export default Notifications;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import Notifications from './components/Notifications.svelte';
+import { getNotificationsContext } from './context';
+import notificationsStore from './store';
 
-export { getNotificationsContext } from './context';
+export { getNotificationsContext, notificationsStore } from './context';
 
 export default Notifications;


### PR DESCRIPTION
We are already creating a store, why not just expose it for those who don't want to use the context api (like me).
Stores easily allow us to create our own abstracted toasting modules without it having to be in the context of a component.
And it allows those who desire to avoid wrapping their app component.

Best of both worlds.

In root of app (if thats where it is desired)
```
<script>
  import Notifications from 'svelte-notifications';
</script>

<Notifications />
<App />
```

Somewhere else, for ex in a reusable js module
```
import { notificationsStore } from 'svelte-notifications';

const { addNotification } = notificationsStore;
const defaultTimeout = 3500;
const successToast = (msg, timeout) => addNotification({..., removeAfter: timeout || defaultTimeout});

export default { successToast };
```

Inside a component
```
<script>
  import { successToast } from 'examplePath';
  
  const clickHandler = () => successToast('Clicked successfully!', 4000);
</script>
```