### PR TITLE
Fix Error: Package subpath './compiler.js' ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-livereload": "^1.0.4",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-svelte": "^5.1.1",
+    "rollup-plugin-svelte": "^6.1.1",
     "rollup-plugin-terser": "^5.2.0",
     "sirv-cli": "^0.4.5",
     "start-server-and-test": "^1.10.8",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -60,7 +60,7 @@ const config = production ? ({
     svelte({
       dev: !production,
       preprocess: preprocess(preprocessOptions),
-      css: css => css.write('public/bundle.css'),
+      css: css => css.write('bundle.css'),
     }),
     resolve(),
     commonjs(),


### PR DESCRIPTION
Error: Package subpath './compiler.js' is not defined by "exports" in node_modules/svelte/package.json
More info: https://github.com/Samuel-Martineau/generator-svelte/issues/7#issuecomment-725330501