### PR TITLE
fix: Import documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install --save svelte-notifications
 // MainComponent.svelte
 
 <script>
-  import Notifications from 'svelte-notifications';
+  import { Notifications } from 'svelte-notifications';
 
   import App from './App.svelte';
 </script>


### PR DESCRIPTION
The export from index.d.ts looks like: `export { NotificationsProps, Notifications, getNotificationsContext }`

The README said to use `import Notifications from 'svelte-notifications';`. This obviously doesn't work. The correct import is `import { Notifications } from 'svelte-notifications'`.