### PR TITLE
fix: Fixed typings of NotificationsContext

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,17 +17,14 @@ interface DefaultNotificationOptions {
     removeAfter?: number;
 }
 
-type addNotification = (notification: DefaultNotificationOptions | Record<string, any>) => void;
-
-type removeNotification = (notificationId: string) => void
-
-type clearNotifications = () => void;
-
-declare function getNotificationsContext(): {
+type NotificationsContext = {
+    // TODO: type subscribe
     subscribe: any;
-    addNotification(): addNotification;
-    removeNotification(): removeNotification;
-    clearNotifications(): clearNotifications;
-};
+    addNotification: (notification: DefaultNotificationOptions | Record<string, any>) => void;
+    removeNotification: (notificationId: string) => void;
+    clearNotifications: () => void;
+}
+
+declare function getNotificationsContext(): NotificationsContext;
 
 export { NotificationsProps, Notifications, getNotificationsContext }


### PR DESCRIPTION
Previously, the return types for `getNotificationsContext` were incorrect:

```ts
// previous type
// (a function accepting 0 arguments returning a function accepting one argument returning void)
addNotification: () => (notification: DefaultNotificationOptions | Record<string, any>) => void;

// correct type
// (a function accepting one argument and returning void)
addNotification: (notification: DefaultNotificationOptions | Record<string, any>) => void;
```

In addition, I just went ahead and typed the entire return value of `NotificationsContext`, as that's the more idiomatic thing to do here.