### PR TITLE
Extract position type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,10 +9,12 @@ export default class Notifications extends SvelteComponent {
   $$prop_def: NotificationsProps;
 }
 
+export type Position = 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right';
+
 interface DefaultNotificationOptions {
   id?: string;
   text: string;
-  position: 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right';
+  position: Position;
   type?: 'success' | 'warning' | 'danger';
   removeAfter?: number;
 }


### PR DESCRIPTION
Extract position type so that it will be easier for developer to cooperate type in their own project.