### PR TITLE
Add default configs as props of Notifications component (fix #24)

### DIFF
--- a/example/App.svelte
+++ b/example/App.svelte
@@ -14,6 +14,6 @@
   };
 </script>
 
-<Notifications {item} zIndex={5000}>
+<Notifications {item} zIndex={5000} defaults={{removeAfter: 1000, position: 'top-right'}}>
   <Children {toggleItemType} />
 </Notifications>

--- a/example/Children.svelte
+++ b/example/Children.svelte
@@ -16,7 +16,7 @@
 
   const setPosition = ({ target }) => {
     if (target && target.id) {
-      position = target.id;
+      position = position === target.id ? '' : target.id;
     }
   };
 

--- a/src/components/Notification.svelte
+++ b/src/components/Notification.svelte
@@ -7,11 +7,10 @@
   export let notification = {};
   export let withoutStyles = false;
 
-  const { removeNotification } = getNotificationsContext();
-  const {
-    id,
-    removeAfter,
-  } = notification;
+  const { removeNotification, defaults } = getNotificationsContext();
+
+  const { id } = notification;
+  const removeAfter = +notification.removeAfter || $defaults.removeAfter;
 
   const removeNotificationHandler = () => removeNotification(id);
 

--- a/src/components/Notifications.svelte
+++ b/src/components/Notifications.svelte
@@ -55,6 +55,10 @@
   export let withoutStyles = false;
   export let zIndex = null;
 
+  export let defaults;
+
+  $: store.defaults.set(defaults);
+
   const getClass = (position = '') => {
     const defaultPositionClass = ` default-position-style-${position}`;
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,10 +6,15 @@ import clearNotification from './actions/clearNotifications';
 
 const createStore = () => {
   const store = writable([]);
+  const defaults = writable({});
+
+  let defaultPosition;
+  defaults.subscribe(({position}) => defaultPosition = position);
 
   return {
+    defaults,
     subscribe: store.subscribe,
-    addNotification: (notification) => addNotification(notification, store),
+    addNotification: async (notification) => addNotification({...notification, position: notification.position || defaultPosition}, store),
     removeNotification: (notificationId) => removeNotification(notificationId, store),
     clearNotifications: () => clearNotification(store),
   };


### PR DESCRIPTION
Hello there,

I added the default config as props of Notifications component. I'd like to know if the implementation is okay with you and I can document it then. I fixed the 0 timeout still showing a notification. It now takes the default removeAfter value. I updated the example to be able to unselect a direction value.

The cypress tests are currently failing because of the new ability to unselect a position in the example. We can fix that by either:

- unset the default position
- unselect the default position in the beforeEach method