### PR TITLE
Suspend notification fading when mouse is over any notification

### DIFF
--- a/src/components/DefaultNotification.svelte
+++ b/src/components/DefaultNotification.svelte
@@ -99,6 +99,8 @@
     aria-live="polite"
     in:fade
     out:fade
+    on:mouseenter
+    on:mouseleave
   >
     <div class={getClass('content')}>
       <slot>{text}</slot>

--- a/src/components/Notifications.svelte
+++ b/src/components/Notifications.svelte
@@ -55,6 +55,8 @@
   export let withoutStyles = false;
   export let zIndex = null;
 
+  let fadeHalted = false;
+
   const getClass = (position = '') => {
     const defaultPositionClass = ` default-position-style-${position}`;
 
@@ -76,6 +78,7 @@
           <Notification
             {notification}
             {withoutStyles}
+            bind:fadeHalted
             item={item || DefaultNotification}
           />
         {/if}


### PR DESCRIPTION
The behaviour is always used, a setting to disable it should be easy to add.